### PR TITLE
Fix context and meta arguments

### DIFF
--- a/wit/wit.py
+++ b/wit/wit.py
@@ -49,9 +49,9 @@ class Wit(object):
 
         body = {'q': query}
         if context:
-            body['context'] = context
+            body['context'] = json.dumps(context)
         if meta:
-            body['meta'] = meta
+            body['meta'] = json.dumps(meta)
         if msg_id:
             body['msg_id'] = msg_id
 
@@ -80,9 +80,9 @@ class Wit(object):
 
         params = {}
         if context:
-            params['context'] = context
+            params['context'] = json.dumps(context)
         if meta:
-            params['meta'] = meta
+            params['meta'] = json.dumps(meta)
         if msg_id:
             params['msg_id'] = msg_id
 


### PR DESCRIPTION
Before you couldn't just pass in an arbitrary dict into context or meta, it needed to already needed to have be a json object, or else you would err on line 37 of wit.py due to a bad request.  

Also noticed you have a develop branch if you prefer me to open a new PR to there instead of straight to master.
