### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PyWit (Unofficial)
 
 [![Build Status](https://travis-ci.org/lextoumbourou/PyWit.png?branch=master)](https://travis-ci.org/lextoumbourou/PyWit)
-[![License](https://pypip.in/license/PyWit/badge.png)](https://pypi.python.org/pypi/PyWit)
-[![Latest Version](https://pypip.in/version/PyWit/badge.png)](https://pypi.python.org/pypi/PyWit)
-[![Downloads](https://pypip.in/download/PyWit/badge.png)](https://pypi.python.org/pypi/PyWit)
+[![License](https://img.shields.io/pypi/l/PyWit.svg)](https://pypi.python.org/pypi/PyWit)
+[![Latest Version](https://img.shields.io/pypi/v/PyWit.svg)](https://pypi.python.org/pypi/PyWit)
+[![Downloads](https://img.shields.io/pypi/dm/PyWit.svg)](https://pypi.python.org/pypi/PyWit)
 
 *Note: Wit.ai now provides an official Python SDK also called [pywit](https://github.com/wit-ai/pywit). It is the recommended way to develop Wit applications in Python.*
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pywit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pywit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.